### PR TITLE
Add custom instrumentation in a plug

### DIFF
--- a/lib/chip_web/controllers/page_controller.ex
+++ b/lib/chip_web/controllers/page_controller.ex
@@ -13,4 +13,9 @@ defmodule ChipWeb.PageController do
     render(conn, "bar.html")
   end
 
+  def custom(conn, _params) do
+    conn
+  |> send_resp(201, "special case handling of /custom endpoint")
+  end
+
 end

--- a/lib/chip_web/custom_plug.ex
+++ b/lib/chip_web/custom_plug.ex
@@ -11,8 +11,13 @@ defmodule ChipWeb.CustomPlug do
     Appsignal.instrument "ChipWeb.CustomPlug", fn ->
       Process.sleep(1000)
       conn
-      |> Conn.send_resp(200, "special case handling of /custom endpoint")
-      |> Conn.halt
+
+      # By halting the response the rest of the plugs aren't called anymore,
+      # so the parent span (the one started by Phoenix in this example) is never closed.
+      # The child span, which _is_ closed, therefor gets dropped.
+
+      # |> Conn.send_resp(200, "special case handling of /custom endpoint")
+      # |> Conn.halt
     end
   end
 
@@ -20,4 +25,4 @@ defmodule ChipWeb.CustomPlug do
     conn
   end
 
-end 
+end

--- a/lib/chip_web/router.ex
+++ b/lib/chip_web/router.ex
@@ -14,6 +14,7 @@ defmodule ChipWeb.Router do
     get "/",    PageController, :index
     get "/foo", PageController, :foo
     get "/bar", PageController, :bar
+    get "/custom", PageController, :custom
   end
 
 end


### PR DESCRIPTION
Added the missing route and its associated action, removed the halt inside the plug as that causes the instrumentation to not get reported in AppSignal.